### PR TITLE
Dev

### DIFF
--- a/examples/all.rs
+++ b/examples/all.rs
@@ -67,6 +67,6 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     tokio::spawn(async move { websocket.subscribe().await });
-
+    #[warn(clippy::empty_loop)]
     loop {}
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use tracing::info;
 
-pub type Callback<T> = Box<dyn (Fn(T) -> ()) + Send + Sync>;
+pub type Callback<T> = Box<dyn (Fn(T)) + Send + Sync>;
 
 #[derive(Clone)]
 pub struct Callbacks {
@@ -97,20 +97,20 @@ impl Default for Callbacks {
 impl Callbacks {
     pub fn on_chart_data(
         mut self,
-        f: impl Fn((ChartOptions, Vec<DataPoint>)) -> () + Send + Sync + 'static,
+        f: impl Fn((ChartOptions, Vec<DataPoint>)) + Send + Sync + 'static,
     ) -> Self {
         self.on_chart_data = Arc::new(Box::new(f));
         self
     }
 
-    pub fn on_quote_data(mut self, f: impl Fn(QuoteValue) -> () + Send + Sync + 'static) -> Self {
+    pub fn on_quote_data(mut self, f: impl Fn(QuoteValue) + Send + Sync + 'static) -> Self {
         self.on_quote_data = Arc::new(Box::new(f));
         self
     }
 
     pub fn on_study_data(
         mut self,
-        f: impl Fn((StudyOptions, StudyResponseData)) -> () + Send + Sync + 'static,
+        f: impl Fn((StudyOptions, StudyResponseData)) + Send + Sync + 'static,
     ) -> Self {
         self.on_study_data = Arc::new(Box::new(f));
         self
@@ -118,20 +118,20 @@ impl Callbacks {
 
     pub fn on_error(
         mut self,
-        f: impl Fn((Error, Vec<Value>)) -> () + Send + Sync + 'static,
+        f: impl Fn((Error, Vec<Value>)) + Send + Sync + 'static,
     ) -> Self {
         self.on_error = Arc::new(Box::new(f));
         self
     }
 
-    pub fn on_symbol_info(mut self, f: impl Fn(SymbolInfo) -> () + Send + Sync + 'static) -> Self {
+    pub fn on_symbol_info(mut self, f: impl Fn(SymbolInfo) + Send + Sync + 'static) -> Self {
         self.on_symbol_info = Arc::new(Box::new(f));
         self
     }
 
     pub fn on_series_completed(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_series_completed = Arc::new(Box::new(f));
         self
@@ -139,7 +139,7 @@ impl Callbacks {
 
     pub fn on_series_loading(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_series_loading = Arc::new(Box::new(f));
         self
@@ -147,25 +147,25 @@ impl Callbacks {
 
     pub fn on_quote_completed(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_quote_completed = Arc::new(Box::new(f));
         self
     }
 
-    pub fn on_replay_ok(mut self, f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static) -> Self {
+    pub fn on_replay_ok(mut self, f: impl Fn(Vec<Value>) + Send + Sync + 'static) -> Self {
         self.on_replay_ok = Arc::new(Box::new(f));
         self
     }
 
-    pub fn on_replay_point(mut self, f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static) -> Self {
+    pub fn on_replay_point(mut self, f: impl Fn(Vec<Value>) + Send + Sync + 'static) -> Self {
         self.on_replay_point = Arc::new(Box::new(f));
         self
     }
 
     pub fn on_replay_instance_id(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_replay_instance_id = Arc::new(Box::new(f));
         self
@@ -173,7 +173,7 @@ impl Callbacks {
 
     pub fn on_replay_resolutions(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_replay_resolutions = Arc::new(Box::new(f));
         self
@@ -181,7 +181,7 @@ impl Callbacks {
 
     pub fn on_replay_data_end(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_replay_data_end = Arc::new(Box::new(f));
         self
@@ -189,7 +189,7 @@ impl Callbacks {
 
     pub fn on_study_loading(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_study_loading = Arc::new(Box::new(f));
         self
@@ -197,7 +197,7 @@ impl Callbacks {
 
     pub fn on_study_completed(
         mut self,
-        f: impl Fn(Vec<Value>) -> () + Send + Sync + 'static,
+        f: impl Fn(Vec<Value>) + Send + Sync + 'static,
     ) -> Self {
         self.on_study_completed = Arc::new(Box::new(f));
         self
@@ -205,7 +205,7 @@ impl Callbacks {
 
     pub fn on_unknown_event(
         mut self,
-        f: impl Fn((String, Vec<Value>)) -> () + Send + Sync + 'static,
+        f: impl Fn((String, Vec<Value>)) + Send + Sync + 'static,
     ) -> Self {
         self.on_unknown_event = Arc::new(Box::new(f));
         self

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -375,6 +375,34 @@ pub enum Interval {
     Yearly = 19,
 }
 
+impl From<&str> for Interval {
+    fn from(value: &str) -> Self {
+        match value {
+            "1s" => Interval::OneSecond,
+            "5s" => Interval::FiveSeconds,
+            "10s" => Interval::TenSeconds,
+            "15s" => Interval::FifteenSeconds,
+            "30s" => Interval::ThirtySeconds,
+            "1m" => Interval::OneMinute,
+            "3m" => Interval::ThreeMinutes,
+            "5m" => Interval::FiveMinutes,
+            "15m" => Interval::FifteenMinutes,
+            "30m" => Interval::ThirtyMinutes,
+            "45m" => Interval::FortyFiveMinutes,
+            "1h" => Interval::OneHour,
+            "2h" => Interval::TwoHours,
+            "4h" => Interval::FourHours,
+            "1d" => Interval::Daily,
+            "7d" => Interval::Weekly,
+            "30d" => Interval::Monthly,
+            "120d" => Interval::Quarterly,
+            "180d" => Interval::SixMonths,
+            "1y" => Interval::Yearly,
+            _ => panic!("Invalid interval: {}", value),
+        }
+    }
+}
+
 impl Display for Interval {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let time_interval = match self {


### PR DESCRIPTION
This pull request introduces several changes, including a new implementation for converting strings to the `Interval` enum, updates to callback function signatures for improved clarity, and a minor addition of a Clippy lint warning. The changes enhance code maintainability and correctness.

### Enhancements to `Interval` Enum:
* Added an implementation of the `From<&str>` trait for the `Interval` enum to allow conversion from string representations (e.g., `"1s"`, `"1m"`) to `Interval` variants. This includes a panic for invalid inputs to ensure correctness. (`src/models/mod.rs`, [src/models/mod.rsR378-R405](diffhunk://#diff-65dcb7295e458c4497f2ccabf12132136e383dd5f0b2c006375eeb43200b34a3R378-R405))

### Updates to Callback Function Signatures:
* Removed redundant `-> ()` return type from various callback function definitions in `Callback` type and `Callbacks` struct methods, simplifying the function signatures. (`src/callback.rs`, [[1]](diffhunk://#diff-2795162389b3db4685d18117cb326d8790376dc2af8d11d21d3ff84484a15c2aL13-R13) [[2]](diffhunk://#diff-2795162389b3db4685d18117cb326d8790376dc2af8d11d21d3ff84484a15c2aL100-R208)

### Minor Code Adjustments:
* Added a Clippy lint warning (`#[warn(clippy::empty_loop)]`) to the infinite loop in the `main` function to improve code quality by flagging potential issues during compilation. (`examples/all.rs`, [examples/all.rsL70-R70](diffhunk://#diff-645a6bbd40759b62709d84e45dd4e37d5958ba83e1618d4b397713d99f77f3edL70-R70))